### PR TITLE
Expose `bytesused` to users

### DIFF
--- a/examples/save-jpeg.rs
+++ b/examples/save-jpeg.rs
@@ -32,14 +32,16 @@ fn main() -> anyhow::Result<()> {
         device.capabilities()?.device_capabilities()
     );
 
-    let capture = device.video_capture(PixFormat::new(u32::MAX, u32::MAX, PixelFormat::JPEG))?;
+    let capture = device.video_capture(PixFormat::new(u32::MAX, u32::MAX, PixelFormat::MJPG))?;
+    
     println!("negotiated format: {:?}", capture.format());
 
     let mut stream = capture.into_stream()?;
 
     println!("stream started, waiting for data");
     stream.dequeue(|buf| {
-        file.write_all(&*buf)?;
+        let bytesused = usize::try_from (buf.bytesused ()).unwrap ();
+        file.write_all(&buf [0..bytesused])?;
         println!("wrote file");
         Ok(())
     })?;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -224,6 +224,7 @@ impl ReadStream {
             unsafe { slice::from_raw_parts(buffer.ptr as *const u8, buffer.length as usize) };
         let view = ReadBufferView {
             flags: buf.flags,
+            bytesused: buf.bytesused,
             data,
         };
 
@@ -282,10 +283,15 @@ impl AsRawFd for ReadStream {
 /// Dereferences to a byte slice.
 pub struct ReadBufferView<'a> {
     flags: BufFlag,
+    bytesused: u32,
     data: &'a [u8],
 }
 
 impl ReadBufferView<'_> {
+    pub fn bytesused(&self) -> u32 {
+        self.bytesused
+    }
+    
     /// Returns whether the error flag for this buffer is set.
     ///
     /// If this returns `true`, the application should expect data corruption in the buffer data.


### PR DESCRIPTION
This lets users copy JPEG frames better.
Previously, when you read JPEG frames, it tells you the length of the frame is `size_image`, the maximum possible length. So it copies a bunch of zeroes and then if you write them to a file, the file is bigger than the actual JPEG contents.